### PR TITLE
Coverage: request specs for all non-GET endpoints + Avo CRUD system spec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,7 +369,7 @@ GEM
       activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.2.4)
+    rack (3.2.6)
     rack-mini-profiler (3.3.1)
       rack (>= 1.2.0)
     rack-session (2.1.1)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -45,6 +45,25 @@
         915
       ],
       "note": "Role is student or faculty_staff"
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 121,
+      "fingerprint": "98b26f60d776fd41ee6f088c833725145be9aac2d7c5b33780241c273622db42",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 7.2.3 ends on 2026-08-09",
+      "file": "Gemfile.lock",
+      "line": 382,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [
+        1104
+      ],
+      "note": "Rails 8 upgrade in progress (stacked PRs); remove this ignore when the Rails 8.0 PR lands"
     }
   ],
   "brakeman_version": "7.0.0"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -52,6 +52,7 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Devise::Test::IntegrationHelpers, type: :system
+  config.include Devise::Test::IntegrationHelpers, type: :request
 
   config.include ActiveSupport::Testing::TimeHelpers
 end

--- a/spec/requests/avo/tools_spec.rb
+++ b/spec/requests/avo/tools_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Avo Tools", type: :request do
+  describe "GET /admin/import_customers_download_template" do
+    it "downloads the customer import template" do
+      sign_in create(:admin_user, :super_admin)
+
+      get avo.import_customers_download_template_path(format: :csv)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/csv")
+      expect(response.body).to eq(Process::Customer::BulkImport.csv_template)
+    end
+  end
+
+  describe "GET /admin/import_items_download_template" do
+    it "downloads the item import template" do
+      sign_in create(:admin_user, :super_admin)
+
+      get avo.import_items_download_template_path(format: :csv)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/csv")
+      expect(response.body).to eq(Process::Item::BulkImport.csv_template)
+    end
+  end
+end

--- a/spec/requests/cart_spec.rb
+++ b/spec/requests/cart_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "Cart", type: :request do
+  describe "GET /cart/add_items" do
+    it "appends the item to the cart via turbo stream" do
+      group = create(:group)
+      admin_user = create(:admin_user, groups: [group])
+      sign_in admin_user
+
+      item = create(:item, group:)
+
+      get cart_add_items_path,
+        params: {item_ids: [item.id], replacement_target: "cart-items"},
+        headers: {"Accept" => "text/vnd.turbo-stream.html"}
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include('<turbo-stream action="append" target="cart-items">')
+      expect(response.body).to include(item.name)
+    end
+  end
+
+  describe "DELETE /cart/remove_items" do
+    it "removes the target via turbo stream" do
+      group = create(:group)
+      admin_user = create(:admin_user, groups: [group])
+      sign_in admin_user
+
+      item = create(:item, group:)
+
+      delete cart_remove_items_path,
+        params: {item_ids: [item.id], replacement_target: "cart-items"},
+        headers: {"Accept" => "text/vnd.turbo-stream.html"}
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('<turbo-stream action="remove" target="cart-items">')
+    end
+  end
+
+  it "is not routable when signed out" do
+    get cart_add_items_path, params: {item_ids: []}
+
+    expect(response).to have_http_status(:not_found)
+  end
+end

--- a/spec/requests/customers/checkouts_spec.rb
+++ b/spec/requests/customers/checkouts_spec.rb
@@ -1,37 +1,34 @@
 require "rails_helper"
 
-RSpec.describe Customers::CheckoutsController, type: :controller do
-  context "when signed in" do
-    describe "POST /create" do
-      it "checks out equipment" do
-        group = create(:group)
-        admin_user = create(:admin_user, groups: [group])
-        sign_in admin_user
+RSpec.describe "Customer Checkouts", type: :request do
+  describe "POST /customers/:customer_id/checkouts" do
+    it "checks out equipment" do
+      group = create(:group)
+      admin_user = create(:admin_user, groups: [group])
+      sign_in admin_user
 
-        item = create(:item, group:)
-        customer = create(:customer)
-        expected_return_on = 1.day.from_now.to_date
+      item = create(:item, group:)
+      customer = create(:customer)
+      expected_return_on = 1.day.from_now.to_date
 
-        post :create, params: {customer_id: customer.id, expected_return_on:, item_ids: [item.id]}
-        expect(response).to have_http_status(:redirect)
-        expect(flash[:notice]).to eq("1 Item checked out to #{customer.title}")
-        expect(response).to redirect_to(customer)
-      end
+      expect {
+        post customer_checkouts_path(customer), params: {expected_return_on:, item_ids: [item.id]}
+      }.to change(Checkout.checked_out, :count).by(1)
+
+      expect(response).to redirect_to(customer_path(customer))
+      expect(response).to have_http_status(:see_other)
+      expect(flash[:notice]).to eq("1 Item checked out to #{customer.title}")
+      expect(item.reload).not_to be_available
     end
-  end
 
-  context "when not signed in" do
-    describe "POST /create" do
-      it "checks out equipment" do
-        group = create(:group)
-        item = create(:item, group:)
-        customer = create(:customer)
-        expected_return_on = 1.day.from_now.to_date
+    it "is not routable when signed out" do
+      customer = create(:customer)
 
-        post :create, params: {customer_id: customer.id, expected_return_on:, item_ids: [item.id]}
+      expect {
+        post customer_checkouts_path(customer), params: {item_ids: []}
+      }.not_to change(Checkout, :count)
 
-        expect(response).to redirect_to(new_admin_user_session_path)
-      end
+      expect(response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/requests/customers/reminders_spec.rb
+++ b/spec/requests/customers/reminders_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "Customer Reminders", type: :request do
+  describe "POST /customers/:customer_id/reminders" do
+    it "sends a reminder email" do
+      admin_user = create(:admin_user)
+      sign_in admin_user
+
+      customer = create(:customer)
+
+      expect {
+        post customer_reminders_path(customer), params: {reminder: {body: "Please return your items"}}
+      }.to have_enqueued_mail(CustomerMailer, :reminder_email)
+
+      expect(response).to redirect_to(customer_path(customer))
+      expect(flash[:notice]).to eq("Reminder was sent to #{customer.name}.")
+    end
+
+    it "is not routable when signed out" do
+      customer = create(:customer)
+
+      expect {
+        post customer_reminders_path(customer), params: {reminder: {body: "hi"}}
+      }.not_to have_enqueued_mail(CustomerMailer, :reminder_email)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/customers/returns_spec.rb
+++ b/spec/requests/customers/returns_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "Customer Returns", type: :request do
+  describe "POST /customers/:customer_id/returns" do
+    it "returns checked out items" do
+      group = create(:group)
+      admin_user = create(:admin_user, groups: [group])
+      sign_in admin_user
+
+      customer = create(:customer)
+      item = create(:item, group:)
+      checkout = create(:checkout, customer:, item:)
+
+      post customer_returns_path(customer), params: {checkout_ids: [checkout.id]}
+
+      expect(response).to redirect_to(customer_path(customer))
+      expect(response).to have_http_status(:see_other)
+      expect(flash[:notice]).to eq("1 Item returned for #{customer.name}")
+      expect(checkout.reload.returned_at).to be_present
+    end
+
+    it "is not routable when signed out" do
+      customer = create(:customer)
+      checkout = create(:checkout, customer:)
+
+      post customer_returns_path(customer), params: {checkout_ids: [checkout.id]}
+
+      expect(response).to have_http_status(:not_found)
+      expect(checkout.reload.returned_at).to be_nil
+    end
+  end
+end

--- a/spec/requests/customers_spec.rb
+++ b/spec/requests/customers_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Customers", type: :request do
+  describe "POST /customers" do
+    it "creates a customer and redirects" do
+      sign_in create(:admin_user)
+
+      expect {
+        post customers_path, params: {customer: attributes_for(:customer)}
+      }.to change(Customer, :count).by(1)
+
+      expect(response).to redirect_to(customer_path(Customer.last))
+    end
+
+    it "re-renders the form with 422 for invalid input" do
+      sign_in create(:admin_user)
+
+      expect {
+        post customers_path, params: {customer: {name: "", ohio_id: ""}}
+      }.not_to change(Customer, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it "is not routable when signed out" do
+      post customers_path, params: {customer: attributes_for(:customer)}
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/system/avo/location_crud_spec.rb
+++ b/spec/system/avo/location_crud_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "Avo Location CRUD", type: :system do
+  it "creates and edits a location through the admin UI" do
+    admin_user = create(:admin_user, :super_admin, password: "abcd1234")
+    sign_in admin_user
+
+    visit "/admin/resources/locations/new"
+
+    find("input[name='location[name]']").fill_in with: "Media Annex"
+    click_on "Save"
+
+    expect(page).to have_content "Media Annex"
+    location = Location.find_by!(name: "Media Annex")
+
+    visit "/admin/resources/locations/#{location.id}/edit"
+    find("input[name='location[name]']").fill_in with: "Media Annex Renamed"
+    click_on "Save"
+
+    expect(page).to have_content "Media Annex Renamed"
+    expect(location.reload.name).to eq("Media Annex Renamed")
+  end
+end


### PR DESCRIPTION
Phase 1 of the Rails 8.1 upgrade plan — the safety net before anything moves.

## What's covered

- **Request specs for every app non-GET endpoint**: `customers#create` (success / invalid-422 / signed-out), nested `checkouts#create`, `returns#create`, `reminders#create` (mail enqueued), and both cart turbo_stream endpoints.
- **Request specs for the two real custom Avo endpoints** (CSV import template downloads).
- **System spec driving Avo location create/edit** through headless Chrome — proves the admin JS stack end-to-end before the Avo/Rails bumps ride on it.
- Rewrote the controller-type spec that lived in `spec/requests/` as a real request spec; added Devise integration helpers for `type: :request`.

## Findings worth knowing

1. **Signed-out behavior is 404, not a sign-in redirect.** `AdminConstraint` unmatches the route before Devise runs. The old controller specs asserted a redirect, but controller specs bypass routing constraints — fantasy behavior. The new specs pin reality.
2. **`/admin/resources/items/not_checked_out_items` is dead AND broken** — no callers anywhere, and it 500s when hit (`ItemPolicy#not_checked_out_items?` doesn't exist). Same for the `past_due` / `checked_out` tool routes: no controller actions, no templates, menu section commented out. All get **deleted in the next PR** rather than specced.
3. **`reminders#create` re-renders invalid input with 200** (no `status:`) — Turbo silently ignores 200 form re-renders. The invalid path is near-unreachable today (body auto-defaults), so left as-is; will be addressed with the Turbo/422 sweep in the Rails 8.1 phase.
4. No wall-clock assertions in the suite — CI needs no `TZ` var.

Full suite locally: 120 examples, 0 failures, 1 pre-existing pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzjQ32Xzsw9uJvz3nGi97f